### PR TITLE
bugfix mkdir & mkdirSync

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -738,10 +738,10 @@ function mkdir(path, options, callback) {
   } else if (typeof options === 'number' || typeof options === 'string') {
     options = { mode: options };
   }
-  const {
+  options = options || {
     recursive = false,
     mode = 0o777
-  } = options || {};
+  };
   callback = makeCallback(callback);
   path = toPathIfFileURL(path);
 
@@ -760,10 +760,10 @@ function mkdirSync(path, options) {
     options = { mode: options };
   }
   path = toPathIfFileURL(path);
-  const {
+  options = options || {
     recursive = false,
     mode = 0o777
-  } = options || {};
+  };
 
   validatePath(path);
   if (typeof recursive !== 'boolean')


### PR DESCRIPTION
lib: - fix issue in fs.js

Fixes: https://github.com/nodejs/node/issues/24698
Refs: https://nodejs.org/api/fs.html#fs_fs_mkdir_path_options_callback

Supplied options of `mkdir` & `mkdirSync` were being overwritten by defaults causing `recursive` flag to be ignored and always be `false`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
